### PR TITLE
Implement and test optional queries for the GET /reviews endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -105,18 +105,23 @@ describe('/api/categories', () => {
                 })
             })
             test('Optional parameters - sort_by - invalid input', () => {
-                return request(app).get('/api/reviews?sort_by=beans').expect(200).then(({body}) => {
-                    expect(body).toBeSortedBy('created_at', {descending: true})
+                return request(app).get('/api/reviews?sort_by=beans').expect(400).then(({body}) => {
+                    expect(body.msg).toBe("Invalid sort_by; please refer to documentation.")
                 })
             })
             test('Optional parameters - order - invalid input', () => {
-                return request(app).get('/api/reviews?order=yes').expect(200).then(({body}) => {
-                    expect(body).toBeSortedBy('created_at', {descending: true})
+                return request(app).get('/api/reviews?order=yes').expect(400).then(({body}) => {
+                    expect(body.msg).toBe("Results must be ordered by ASC or DESC")
                 })
             })
             test('Optional parameters - order - invalid but possible input', () => {
                 return request(app).get('/api/reviews?category=funnygames').expect(200).then(({body}) => {
                     expect(body.length).toBe(0)
+                })
+            })
+            test('Optional parameters - default case', () => {
+                return request(app).get('/api/reviews').expect(200).then(({body}) => {
+                    expect(body).toBeSortedBy('created_at', {descending: true})
                 })
             })
         })

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -3,6 +3,7 @@ const db = require('../db/connection')
 const seed = require('../db/seeds/seed')
 const testData = require('../db/data/test-data/index')
 const request = require('supertest')
+require('jest-sorted')
 
 beforeEach(() => {
     return seed(testData)
@@ -84,6 +85,38 @@ describe('/api/categories', () => {
                         }))
                     })
                     expect(body[4].comment_count).toBe(3)
+                })
+            })
+            test('Optional parameters - sort_by', () => {
+                return request(app).get('/api/reviews?sort_by=votes').expect(200).then(({body}) => {
+                    expect(body).toBeSortedBy('votes', {descending: true})
+                })
+            })
+            test('Optional parameters - order', () => {
+                return request(app).get('/api/reviews?order=asc').expect(200).then(({body}) => {
+                    expect(body).toBeSortedBy('created_at')
+                })
+            })
+            test('Optional parameters - category', () => {
+                return request(app).get('/api/reviews?category=euro%20game').expect(200).then(({body}) => {
+                    body.forEach(game => {
+                        expect(game.category).toBe('euro game')
+                    })
+                })
+            })
+            test('Optional parameters - sort_by - invalid input', () => {
+                return request(app).get('/api/reviews?sort_by=beans').expect(200).then(({body}) => {
+                    expect(body).toBeSortedBy('created_at', {descending: true})
+                })
+            })
+            test('Optional parameters - order - invalid input', () => {
+                return request(app).get('/api/reviews?order=yes').expect(200).then(({body}) => {
+                    expect(body).toBeSortedBy('created_at', {descending: true})
+                })
+            })
+            test('Optional parameters - order - invalid but possible input', () => {
+                return request(app).get('/api/reviews?category=funnygames').expect(200).then(({body}) => {
+                    expect(body.length).toBe(0)
                 })
             })
         })

--- a/controllers/reviewController.js
+++ b/controllers/reviewController.js
@@ -7,7 +7,8 @@ const {
 } = require('../models/reviewModel')
 
 exports.getReviews = (req, res, next) => {
-    fetchReviews()
+    const {sort_by, order, category} = req.query
+    fetchReviews(sort_by, order, category)
     .then(reviews => {
         res.status(200).send(reviews)
     })

--- a/models/reviewModel.js
+++ b/models/reviewModel.js
@@ -2,10 +2,10 @@ const db = require('../db/connection')
 const {createRef} = require('../db/seeds/utils')
 
 exports.fetchReviews = (sort_by = 'created_at', order = 'DESC', category) => {
-    const validSorts = ['review_id', 'title', 'category', 'designer', 'owner', 'review_body', 'review_img_url', 'create_at', 'votes']
+    const validSorts = ['review_id', 'title', 'category', 'designer', 'owner', 'review_body', 'review_img_url', 'created_at', 'votes']
     const queries = []
     
-    if (validSorts.indexOf(sort_by) === -1) sort_by = 'created_at'
+    if (validSorts.indexOf(`${sort_by}`) === -1) return Promise.reject({statusCode: 400, msg: "Invalid sort_by; please refer to documentation."})
     
     
     let query = `
@@ -20,10 +20,17 @@ exports.fetchReviews = (sort_by = 'created_at', order = 'DESC', category) => {
     query += `
     GROUP BY reviews.review_id
     ORDER BY reviews.${sort_by} `
-
-    if (order.toUpperCase() === 'ASC') query += 'ASC'
-    else query += 'DESC'
-    
+    order = order.toUpperCase()
+    switch (order) {
+        case 'ASC': 
+            query += 'ASC'
+            break
+        case 'DESC':
+            query += 'DESC'
+            break
+        default:
+            return Promise.reject({statusCode: 400, msg: "Results must be ordered by ASC or DESC"})
+    }
     return db.query(query, queries)
     .then(({rows}) => rows)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "dotenv": "^16.0.0",
+        "jest-sorted": "^1.0.14",
         "pg": "^8.7.3",
         "supertest": "^6.2.4"
       }
@@ -2958,6 +2959,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.14.tgz",
+      "integrity": "sha512-qGMA3ybF15S+4gDtv3XaE/GtEd3YvSepVC3vL63TbxIISkeOS/0HhRZYL12VQGKn0TWyi2/62dh5OO71X9LY3A==",
+      "dev": true
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -6893,6 +6900,12 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.14.tgz",
+      "integrity": "sha512-qGMA3ybF15S+4gDtv3XaE/GtEd3YvSepVC3vL63TbxIISkeOS/0HhRZYL12VQGKn0TWyi2/62dh5OO71X9LY3A==",
+      "dev": true
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "jest-sorted": "^1.0.14",
     "pg": "^8.7.3",
     "supertest": "^6.2.4"
   },


### PR DESCRIPTION
Implement 3 optional queries:
-sort_by - Compares to a list of approved possible queries to avoid SQL injection, defaults to created_by if no match is found; this handles many of the potential errors from user input with a default state

-order - Checks if the order is "ASC" (case insensitive) and if it isn't defaults so descending

-category - Queries for category equal to user input, case sensitive, and if there is no match returns a 200 with an empty array. Potential to expand on this to provide better feedback to the user, but for now it's functional